### PR TITLE
Use "table" instead of "keygroup"

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,16 +93,14 @@ In `emacs-toml`, "key groups" and "key" key pattern are as follows:
 
 ## Test
 
-Use [Cask.el](https://github.com/rejeep/cask.el). follow commands:
+Follow commands:
 
 ```
 $ make test
-cask exec emacs -Q --batch \
+emacs -Q --batch \
 		--load toml.el \
 		--load toml-test.el \
 		-f ert-run-tests-batch-and-exit
-Real cl-lib shadowed by compatibility cl-lib? (/Users/gongo/.emacs.d/elpa/cl-lib-0.3/cl-lib.elc)
-Real cl-lib shadowed by compatibility cl-lib? (/Users/gongo/.emacs.d/elpa/cl-lib-0.3/cl-lib.elc)
 Running 21 tests (2013-08-29 22:33:46+0900)
    passed   1/21  toml-test-error:parse
    passed   2/21  toml-test-error:read-boolean

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ hosts = \[
 In `emacs-toml`, "key groups" and "key" key pattern are as follows:
 
 * `key` = `[a-zA-Z][a-zA-Z0-9_]*`
-* `keygroup` = `[a-zA-Z][a-zA-Z0-9_\\.]*`
+* `table` = `[a-zA-Z][a-zA-Z0-9_\\.]*`
     * The end doesn't end in the period.
 
 ## Test
@@ -109,7 +109,7 @@ Running 21 tests (2013-08-29 22:33:46+0900)
    passed   3/21  toml-test-error:read-datetime
    passed   4/21  toml-test-error:read-escaped-char
    passed   5/21  toml-test-error:read-key
-   passed   6/21  toml-test-error:read-keygroup
+   passed   6/21  toml-test-error:read-table
    passed   7/21  toml-test-error:read-numeric
    passed   8/21  toml-test-error:read-string
    passed   9/21  toml-test:make-hashes
@@ -124,7 +124,7 @@ Mark set
    passed  13/21  toml-test:read-datetime
    passed  14/21  toml-test:read-escaped-char
    passed  15/21  toml-test:read-key
-   passed  16/21  toml-test:read-keygroup
+   passed  16/21  toml-test:read-table
    passed  17/21  toml-test:read-numeric
    passed  18/21  toml-test:read-string
    passed  19/21  toml-test:seek-beginning-of-next-line

--- a/toml-test.el
+++ b/toml-test.el
@@ -206,39 +206,39 @@ aiueo"
    (should-error (toml:read-key) :type 'toml-key-error)))
 
 
-(ert-deftest toml-test:read-keygroup ()
+(ert-deftest toml-test:read-table ()
   (toml-test:buffer-setup
    "[aiueo]"
-   (should (equal '("aiueo") (toml:read-keygroup))))
+   (should (equal '("aiueo") (toml:read-table))))
 
   (toml-test:buffer-setup
    "[servers]
     [servers.alpha]
 
        key = value"
-   (should (equal '("servers" "alpha") (toml:read-keygroup)))
+   (should (equal '("servers" "alpha") (toml:read-table)))
    (should (eq ?k (toml:get-char-at-point))))
 
   (toml-test:buffer-setup
    "[servers]
     [servers.alpha]
     [client]"
-   (should (equal '("client") (toml:read-keygroup)))))
+   (should (equal '("client") (toml:read-table)))))
 
-(ert-deftest toml-test-error:read-keygroup ()
+(ert-deftest toml-test-error:read-table ()
   (toml-test:buffer-setup
    "[]"
-   (should-error (toml:read-keygroup) :type 'toml-keygroup-error))
+   (should-error (toml:read-table) :type 'toml-table-error))
 
   ;; end with underscore "_"
   (toml-test:buffer-setup
    "[foo.bar_]"
-   (should-error (toml:read-keygroup) :type 'toml-keygroup-error))
+   (should-error (toml:read-table) :type 'toml-table-error))
 
   ;; end with period "."
   (toml-test:buffer-setup
    "[foo.bar.]"
-   (should-error (toml:read-keygroup) :type 'toml-keygroup-error)))
+   (should-error (toml:read-table) :type 'toml-table-error)))
 
 (ert-deftest toml-test:make-hashes ()
   (let (hash)
@@ -330,7 +330,7 @@ b = 1
 
 \[a\]
 c = 2"
-   (should-error (toml:read) :type 'toml-redefine-keygroup-error))
+   (should-error (toml:read) :type 'toml-redefine-table-error))
 
   (toml-test:buffer-setup
    "\
@@ -340,4 +340,4 @@ b = 1
 \[a.b\]
 c = 2"
    (should-error (toml:read) :type 'toml-redefine-key-error))
-)
+  )


### PR DESCRIPTION
> ### 0.2.0 / 2013-09-24
> - Use "table" instead of "key group" terminology.
>
> https://github.com/toml-lang/toml/blob/master/CHANGELOG.md#020--2013-09-24