### PR TITLE
Allow dashes in toml keys

### DIFF
--- a/toml-test.el
+++ b/toml-test.el
@@ -21,7 +21,7 @@
 (ert-deftest toml-test:seek-readable-point ()
   (toml-test:buffer-setup
    "\
-   
+
   # comment line
   # comment line 2 # 3
 aiueo"
@@ -180,6 +180,11 @@ aiueo"
    (should (eq ?5 (toml:get-char-at-point))))
 
   (toml-test:buffer-setup
+   "connection-max = name"
+   (should (equal "connection-max" (toml:read-key)))
+   (should (eq ?n (toml:get-char-at-point))))
+
+  (toml-test:buffer-setup
    "server12 = name"
    (should (equal "server12" (toml:read-key)))
    (should (eq ?n (toml:get-char-at-point)))))
@@ -210,6 +215,10 @@ aiueo"
   (toml-test:buffer-setup
    "[aiueo]"
    (should (equal '("aiueo") (toml:read-keygroup))))
+
+  (toml-test:buffer-setup
+   "[ai-ueo]"
+   (should (equal '("ai-ueo") (toml:read-keygroup))))
 
   (toml-test:buffer-setup
    "[servers]

--- a/toml.el
+++ b/toml.el
@@ -319,7 +319,7 @@ Move point to the end of read string."
   (let (keygroup)
     (while (and (not (toml:end-of-buffer-p))
                 (char-equal (toml:get-char-at-point) ?\[))
-      (if (toml:search-forward "\\[\\([a-zA-Z][a-zA-Z0-9_\\.]*\\)\\]")
+      (if (toml:search-forward "\\[\\([a-zA-Z][a-zA-Z0-9_\\.-]*\\)\\]")
           (let ((keygroup-string (match-string-no-properties 1)))
             (when (string-match "\\(_\\|\\.\\)\\'" keygroup-string)
               (signal 'toml-keygroup-error (list (point))))
@@ -331,7 +331,7 @@ Move point to the end of read string."
 (defun toml:read-key ()
   (toml:seek-readable-point)
   (if (toml:end-of-buffer-p) nil
-    (if (toml:search-forward "\\([a-zA-Z][a-zA-Z0-9_]*\\) *= *")
+    (if (toml:search-forward "\\([a-zA-Z][a-zA-Z0-9_-]*\\) *= *")
         (let ((key (match-string-no-properties 1)))
           (when (string-match "_\\'" key)
             (signal 'toml-key-error (list (point))))


### PR DESCRIPTION
According to the specs [1] dashes are allowed in bare keys

_____
[1] https://toml.io/en/v1.0.0-rc.3#keys