### PR TITLE
Allow empty values []

### DIFF
--- a/toml-test.el
+++ b/toml-test.el
@@ -21,7 +21,7 @@
 (ert-deftest toml-test:seek-readable-point ()
   (toml-test:buffer-setup
    "\
-   
+
   # comment line
   # comment line 2 # 3
 aiueo"
@@ -272,10 +272,12 @@ c = 1
 
 \[a\]
 d = 2
+e = []
 "
    (let ((parsed (toml:read)))
      (should (equal '("c" . 1) (toml:assoc '("a" "b" "c") parsed)))
      (should (equal '("d" . 2) (toml:assoc '("a" "d") parsed)))
+     (should (equal '("e" . nil) (toml:assoc '("a" "e") parsed)))
      ))
 
   (toml-test:buffer-setup

--- a/toml.el
+++ b/toml.el
@@ -383,11 +383,10 @@ Move point to the end of read string."
         (signal 'toml-redefine-key-error (list (point))))
 
       (setq current-value (toml:read-value))
-      (when current-value
-        (setq hashes (toml:make-hashes current-keygroup
+      (setq hashes (toml:make-hashes current-keygroup
                                        current-key
                                        current-value
-                                       hashes)))
+                                       hashes))
 
       (toml:seek-readable-point))
     hashes))


### PR DESCRIPTION
In Rust project's `Cargo.toml` files it is a common pattern [1] to define
features like

```toml
[features]
foo = []
bar = []
```

This pattern should be allowed in `toml.el`

The patch simply allows `nil` values. This does not seem to break anything as
all the other tests seem still to pass.
___
[1] https://doc.rust-lang.org/cargo/reference/features.html