### PR TITLE
Add support for literal strings

### DIFF
--- a/toml-test.el
+++ b/toml-test.el
@@ -1,3 +1,5 @@
+(add-to-list 'load-path (file-name-directory (or load-file-name buffer-file-name)))
+
 (require 'ert)
 (require 'toml)
 
@@ -356,3 +358,25 @@ b = 1
 c = 2"
    (should-error (toml:read) :type 'toml-redefine-key-error))
 )
+
+(ert-deftest toml-test:read-literal-string ()
+  (toml-test:buffer-setup
+   "'Literal string with no escapes.'"
+   (should (equal "Literal string with no escapes." (toml:read-literal-string)))
+   (should (toml:end-of-line-p))))
+
+(ert-deftest toml-test:read-empty-literal-string ()
+  (toml-test:buffer-setup
+   "''"
+   (should (equal "" (toml:read-literal-string)))
+   (should (toml:end-of-line-p))))
+
+(ert-deftest toml-test-error:read-literal-string ()
+  (dolist (str '("noquotes"               ;; not quoted
+                 "'unterminated string"   ;; no closing quote
+                 " 'starts with space'"   ;; space before quote
+                 "'''"                    ;; multiple quotes not supported here
+                 ))
+    (toml-test:buffer-setup
+     str
+     (should-error (toml:read-literal-string) :type 'toml-string-error))))

--- a/toml-test.el
+++ b/toml-test.el
@@ -1,5 +1,3 @@
-(add-to-list 'load-path (file-name-directory (or load-file-name buffer-file-name)))
-
 (require 'ert)
 (require 'toml)
 
@@ -372,11 +370,13 @@ c = 2"
    (should (toml:end-of-line-p))))
 
 (ert-deftest toml-test-error:read-literal-string ()
-  (dolist (str '("noquotes"               ;; not quoted
-                 "'unterminated string"   ;; no closing quote
-                 " 'starts with space'"   ;; space before quote
-                 "'''"                    ;; multiple quotes not supported here
-                 ))
-    (toml-test:buffer-setup
-     str
-     (should-error (toml:read-literal-string) :type 'toml-string-error))))
+  (dolist (case '(("'unterminated string"   . toml-string-error)
+                   ;; TODO: perhaps add unsupported err?
+                  ("'''"                    . toml-key-error)))
+    (let* ((input (concat "x = " (car case)))
+           (expected-error (cdr case)))
+      (toml-test:buffer-setup
+       input
+       (if expected-error
+           (should-error (toml:read) :type expected-error)
+         (should (toml:read)))))))

--- a/toml.el
+++ b/toml.el
@@ -53,7 +53,6 @@
 \\\/     - slash           (U+002F)
 \\\\     - backslash       (U+005C)
 
-
 notes:
 
  Excluded four hex (\\uXXXX).  Do check in `toml:read-escaped-char'")
@@ -63,7 +62,7 @@ notes:
          '((?t  . toml:read-boolean)
            (?f  . toml:read-boolean)
            (?\[ . toml:read-array)
-	       (?{  . toml:read-inline-table)
+	   (?{  . toml:read-inline-table)
            (?\" . toml:read-string)
            (?\' . toml:read-literal-string))))
     (mapc (lambda (char)
@@ -178,7 +177,7 @@ notes:
   (beginning-of-line))
 
 (defun toml:seek-readable-point ()
-  "Move point forward, stopping readable point.  (toml->read-table).
+  "Move point forward, stopping readable point. (toml->read-table).
 
 Skip target:
 


### PR DESCRIPTION
Currently, emacs-toml has no support for literal strings, which are part of the TOML v1.0 specification. This can result in confusing errors, particularly when parsing Cargo.toml files in Rust projects. One common case is when the Rust compiler suggests fixes involving cfg flags, which use literal strings. Without support for these, toml.el fails to parse the file, making the experience more difficult than it needs to be.

This patch adds support for literal strings. They are simpler than basic strings, as they do not permit escape sequences. I have included two smoke tests to verify the behavior.