### PR TITLE
Support RFC 3339 datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ emacs-toml
 `toml.el` is a library for parsing TOML (Tom's Obvious, Minimal Language).
 
 * Learn all about TOML here: https://github.com/mojombo/toml
-* Support version: [v0.1.0](https://github.com/mojombo/toml/blob/master/versions/toml-v0.1.0.md)
+* Support version: [v0.2.0](https://github.com/toml-lang/toml/blob/main/CHANGELOG.md#020--2013-09-24)
 
 ## Example
 
@@ -76,7 +76,15 @@ hosts = \[
 ;;        ("ports" . [8001 8001 8002])
 ;;        ("server" . "192.168.1.1"))
 ;;       ("owner"
-;;        ("dob" 0 32 7 27 5 1979)
+;;        ("dob"
+;;         (year . 1979)
+;;         (month . 5)
+;;         (day . 27)
+;;         (hour . 7)
+;;         (minute . 32)
+;;         (second . 0)
+;;         (fraction)
+;;         (timezone . "Z"))
 ;;        ("bio" . "GitHub Cofounder & CEO\\nLikes tater tots and beer.")
 ;;        ("organization" . "GitHub")
 ;;        ("name" . "Tom Preston-Werner"))

--- a/toml-test.el
+++ b/toml-test.el
@@ -109,8 +109,48 @@ aiueo"
 (ert-deftest toml-test:read-datetime ()
   (toml-test:buffer-setup
    "1979-05-27T07:32:00Z"
-   (should (equal '(0 32 7 27 5 1979) (toml:read-datetime)))
+   (let ((dt (toml:read-datetime)))
+     (should (equal 1979 (cdr (assoc 'year dt))))
+     (should (equal 5 (cdr (assoc 'month dt))))
+     (should (equal 27 (cdr (assoc 'day dt))))
+     (should (equal 7 (cdr (assoc 'hour dt))))
+     (should (equal 32 (cdr (assoc 'minute dt))))
+     (should (equal 0 (cdr (assoc 'second dt))))
+     (should (null (cdr (assoc 'fraction dt))))
+     (should (equal "Z" (cdr (assoc 'timezone dt)))))
    (should (toml:end-of-line-p))))
+
+(ert-deftest toml-test:read-datetime-with-timezone ()
+  (toml-test:buffer-setup
+   "1979-05-27T00:32:00-07:00"
+   (let ((dt (toml:read-datetime)))
+     (should (equal 1979 (cdr (assoc 'year dt))))
+     (should (equal 5 (cdr (assoc 'month dt))))
+     (should (equal 27 (cdr (assoc 'day dt))))
+     (should (equal 0 (cdr (assoc 'hour dt))))
+     (should (equal 32 (cdr (assoc 'minute dt))))
+     (should (equal 0 (cdr (assoc 'second dt))))
+     (should (null (cdr (assoc 'fraction dt))))
+     (should (equal "-07:00" (cdr (assoc 'timezone dt))))))
+
+  (toml-test:buffer-setup
+   "1979-05-27T00:32:00+05:30"
+   (let ((dt (toml:read-datetime)))
+     (should (equal "+05:30" (cdr (assoc 'timezone dt)))))))
+
+(ert-deftest toml-test:read-datetime-with-fractional-seconds ()
+  (toml-test:buffer-setup
+   "1979-05-27T00:32:00.999999-07:00"
+   (let ((dt (toml:read-datetime)))
+     (should (equal 1979 (cdr (assoc 'year dt))))
+     (should (equal 5 (cdr (assoc 'month dt))))
+     (should (equal 27 (cdr (assoc 'day dt))))
+     (should (equal 0 (cdr (assoc 'hour dt))))
+     (should (equal 32 (cdr (assoc 'minute dt))))
+     (should (equal 0 (cdr (assoc 'second dt))))
+     (should (floatp (cdr (assoc 'fraction dt))))
+     (should (equal 0.999999 (cdr (assoc 'fraction dt))))
+     (should (equal "-07:00" (cdr (assoc 'timezone dt)))))))
 
 (ert-deftest toml-test-error:read-datetime ()
   (dolist (str '("1979-05-27" "1979-35-27T07:32:00Z" " 1979-05-27T07:32:00Z"))


### PR DESCRIPTION
close #24 

## BREAKING CHANGE

`toml:read-datetime` now returns an alist instead of a list.

### Summary

The return value of `toml:read-datetime` has been changed from a positional list to an alist (association list).

**Before (Old Format)**

```lisp
;; Input: 1979-05-27T07:32:00Z
;; Return: (seconds minutes hour day month year)
(0 32 7 27 5 1979)
```

**After (New Format)**

```lisp
;; Input: 1979-05-27T07:32:00Z
;; Return: alist
((year . 1979)
(month . 5)
(day . 27)
(hour . 7)
(minute . 32)
(second . 0)
(fraction . nil)
(timezone . "Z"))
```
