### PR TITLE
Support multiline strings (`"""` and `'''`)

### DIFF
--- a/toml-test.el
+++ b/toml-test.el
@@ -529,8 +529,7 @@ c = 2"
 
 (ert-deftest toml-test-error:read-literal-string ()
   (dolist (case '(("'unterminated string"   . toml-string-error)
-                   ;; TODO: perhaps add unsupported err?
-                  ("'''"                    . toml-key-error)))
+                  ("'''"                    . toml-string-error)))
     (let* ((input (concat "x = " (car case)))
            (expected-error (cdr case)))
       (toml-test:buffer-setup
@@ -787,3 +786,127 @@ name = \"Jane\""
          (should (equal "Emacs Manual" (cdr (assoc "title" book2))))
          (let ((author (cdr (assoc "author" book2))))
            (should (equal "Jane" (cdr (assoc "name" author))))))))))
+
+(ert-deftest toml-test:read-multiline-basic-string ()
+  (toml-test:buffer-setup
+   "\"\"\"Hello
+World\"\"\""
+   (should (equal "Hello\nWorld" (toml:read-string))))
+
+  (toml-test:buffer-setup
+   "\"\"\"
+One
+Two\"\"\""
+   (should (equal "One\nTwo" (toml:read-string)))))
+
+(ert-deftest toml-test:read-multiline-basic-string-line-continuation ()
+  (toml-test:buffer-setup
+   "\"\"\"The quick brown \\
+    fox jumps over \\
+    the lazy dog.\"\"\""
+   (should (equal "The quick brown fox jumps over the lazy dog." (toml:read-string))))
+
+  (toml-test:buffer-setup
+   "\"\"\"The quick \\
+
+
+    fox\"\"\""
+   (should (equal "The quick fox" (toml:read-string)))))
+
+(ert-deftest toml-test:read-multiline-basic-string-escapes ()
+  (toml-test:buffer-setup
+   "\"\"\"Line1\\nLine2\"\"\""
+   (should (equal "Line1\\nLine2" (toml:read-string))))
+
+  (toml-test:buffer-setup
+   "\"\"\"Tab\\there\"\"\""
+   (should (equal "Tab\\there" (toml:read-string)))))
+
+(ert-deftest toml-test:read-multiline-basic-string-quotes ()
+  (toml-test:buffer-setup
+   "\"\"\"Hello \"\"World\"\"\""
+   (should (equal "Hello \"\"World" (toml:read-string))))
+
+  (toml-test:buffer-setup
+   "\"\"\"Say \"Hello\" to me\"\"\""
+   (should (equal "Say \"Hello\" to me" (toml:read-string)))))
+
+(ert-deftest toml-test:read-multiline-basic-string-empty ()
+  (toml-test:buffer-setup
+   "\"\"\"\"\"\""
+   (should (equal "" (toml:read-string)))))
+
+(ert-deftest toml-test-error:read-multiline-basic-string-unterminated ()
+  (toml-test:buffer-setup
+   "\"\"\"unterminated"
+   (should-error (toml:read-string) :type 'toml-string-error)))
+
+(ert-deftest toml-test:read-multiline-literal-string ()
+  (toml-test:buffer-setup
+   "'''Hello
+World'''"
+   (should (equal "Hello\nWorld" (toml:read-literal-string))))
+
+  (toml-test:buffer-setup
+   "'''
+Text here'''"
+   (should (equal "Text here" (toml:read-literal-string)))))
+
+(ert-deftest toml-test:read-multiline-literal-string-no-escapes ()
+  (toml-test:buffer-setup
+   "'''I [dw]on't need \\d{2} apples'''"
+   (should (equal "I [dw]on't need \\d{2} apples" (toml:read-literal-string))))
+
+  (toml-test:buffer-setup
+   "'''line1\\
+line2'''"
+   (should (equal "line1\\\nline2" (toml:read-literal-string)))))
+
+(ert-deftest toml-test:read-multiline-literal-string-quotes ()
+  (toml-test:buffer-setup
+   "'''Hello ''World'''"
+   (should (equal "Hello ''World" (toml:read-literal-string)))))
+
+(ert-deftest toml-test:read-multiline-literal-string-empty ()
+  (toml-test:buffer-setup
+   "''''''"
+   (should (equal "" (toml:read-literal-string)))))
+
+(ert-deftest toml-test-error:read-multiline-literal-string-unterminated ()
+  (toml-test:buffer-setup
+   "'''unterminated"
+   (should-error (toml:read-literal-string) :type 'toml-string-error)))
+
+
+(ert-deftest toml-test:parse-multiline-strings ()
+  (toml-test:buffer-setup
+   "str1 = \"\"\"
+Roses are red
+Violets are blue\"\"\"
+
+str2 = '''
+The first newline is
+trimmed in raw strings.
+   All other whitespace
+   is preserved.
+'''"
+   (let ((parsed (toml:read)))
+     (should (equal "Roses are red\nViolets are blue"
+                    (cdr (assoc "str1" parsed))))
+     (should (equal "The first newline is\ntrimmed in raw strings.\n   All other whitespace\n   is preserved.\n"
+                    (cdr (assoc "str2" parsed))))))
+
+  (toml-test:buffer-setup
+   "[section]
+multiline = \"\"\"
+This is a
+multiline value
+\"\"\"
+
+regex = '''\\d{4}-\\d{2}-\\d{2}'''
+"
+   (let ((parsed (toml:read)))
+     (should (equal "This is a\nmultiline value\n"
+                    (cdr (assoc "multiline" (cdr (assoc "section" parsed))))))
+     (should (equal "\\d{4}-\\d{2}-\\d{2}"
+                    (cdr (assoc "regex" (cdr (assoc "section" parsed)))))))))

--- a/toml.el
+++ b/toml.el
@@ -240,36 +240,86 @@ Move point to the end of read characters."
       (concat "\\u" (match-string 0)))
      (t (signal 'toml-string-unicode-escape-error (list (point)))))))
 
+(defun toml:read-multiline-basic-string ()
+  "Read multiline basic string (enclosed in \"\"\") at point.
+Handles escape sequences, line-ending backslash continuation,
+and trims immediate newline after opening delimiter."
+  ;; Skip the opening """
+  (forward-char 3)
+  ;; Trim immediate newline after opening delimiter
+  (when (eq (toml:get-char-at-point) ?\n)
+    (forward-char))
+  (let ((characters '()))
+    (while (not (looking-at "\"\"\""))
+      (when (eobp)
+        (signal 'toml-string-error (list (point))))
+      (cond
+       ;; Line-ending backslash: trim the backslash, newline, and following whitespace
+       ((looking-at "\\\\[ \t]*\n[ \t\n]*")
+        (goto-char (match-end 0)))
+       (t
+        (let ((char (toml:get-char-at-point)))
+          ;; Regular escape sequence or regular character
+          (if (eq char ?\\)
+              (push (toml:read-escaped-char) characters)
+            (push (toml:read-char) characters))))))
+    ;; Skip the closing """
+    (forward-char 3)
+    (apply #'concat (nreverse characters))))
+
 (defun toml:read-string ()
   "Read string at point that surrounded by double quotation mark.
 Move point to the end of read strings."
   (unless (eq ?\" (toml:get-char-at-point))
     (signal 'toml-string-error (list (point))))
-  (let ((characters '())
-        (char (toml:read-char)))
-    (while (not (eq char ?\"))
-      (when (toml:end-of-line-p)
+  ;; Check for multiline string (""")
+  (if (looking-at "\"\"\"")
+      (toml:read-multiline-basic-string)
+    (let ((characters '())
+          (char (toml:read-char)))
+      (while (not (eq char ?\"))
+        (when (toml:end-of-line-p)
+          (signal 'toml-string-error (list (point))))
+        (push (if (eq char ?\\)
+                  (toml:read-escaped-char)
+                (toml:read-char))
+              characters)
+        (setq char (toml:get-char-at-point)))
+      (forward-char)
+      (apply 'concat (nreverse characters)))))
+
+(defun toml:read-multiline-literal-string ()
+  "Read multiline literal string (enclosed in ''') at point.
+No escape processing. Trims immediate newline after opening delimiter."
+  ;; Skip the opening '''
+  (forward-char 3)
+  ;; Trim immediate newline after opening delimiter
+  (when (eq (toml:get-char-at-point) ?\n)
+    (forward-char))
+  (let ((characters '()))
+    (while (not (looking-at "'''"))
+      (when (eobp)
         (signal 'toml-string-error (list (point))))
-      (push (if (eq char ?\\)
-                (toml:read-escaped-char)
-              (toml:read-char))
-            characters)
-      (setq char (toml:get-char-at-point)))
-    (forward-char)
-    (apply 'concat (nreverse characters))))
+      (push (toml:read-char) characters))
+    ;; Skip the closing '''
+    (forward-char 3)
+    (apply #'concat (nreverse characters))))
 
 (defun toml:read-literal-string ()
   "Read TOML literal string (enclosed in single quotes) at point."
   (unless (eq ?\' (toml:get-char-at-point))
     (signal 'toml-string-error (list (point))))
-  (forward-char)
-  (let ((characters '()))
-    (while (not (eq (toml:get-char-at-point) ?\'))
-      (when (toml:end-of-line-p)
-        (signal 'toml-string-error (list (point))))
-      (push (toml:read-char) characters))
+  ;; Check for multiline literal string (''')
+  (if (looking-at "'''")
+      (toml:read-multiline-literal-string)
     (forward-char)
-    (apply #'concat (nreverse characters))))
+    (let ((characters '()))
+      (while (not (eq (toml:get-char-at-point) ?\'))
+        (when (toml:end-of-line-p)
+          (signal 'toml-string-error (list (point))))
+        (push (toml:read-char) characters))
+      (forward-char)
+      (apply #'concat (nreverse characters)))))
 
 (defun toml:read-boolean ()
   "Read boolean at point.  Return t or nil.


### PR DESCRIPTION
close #25 

> [!NOTE]
> Escape sequences (e.g., `\n`, `\t`, `\uXXXX`) in multiline basic strings are currently
> stored as literal strings rather than being interpreted. This is a pre-existing bug,
> not introduced by this PR, and will be fixed in a follow-up PR. 