### PR TITLE
Fix escape sequence interpretation in basic strings

### DIFF
--- a/toml-test.el
+++ b/toml-test.el
@@ -59,10 +59,19 @@ aiueo"
    (should (equal ?u (toml:get-char-at-point)))))
 
 (ert-deftest toml-test:read-escaped-char ()
-  (dolist (char '("\\b" "\\t" "\\n" "\\f" "\\r" "\\\"" "\\\/" "\\\\" "\\u1234"))
+  (dolist (test '(("\\b" . "\b")
+                  ("\\t" . "\t")
+                  ("\\n" . "\n")
+                  ("\\f" . "\f")
+                  ("\\r" . "\r")
+                  ("\\\"" . "\"")
+                  ("\\/" . "/")
+                  ("\\\\" . "\\")
+                  ("\\u0041" . "A")
+                  ("\\u1234" . "\u1234")))
     (toml-test:buffer-setup
-     char
-     (should (equal char (toml:read-escaped-char)))
+     (car test)
+     (should (equal (cdr test) (toml:read-escaped-char)))
      (should (toml:end-of-line-p)))))
 
 (ert-deftest toml-test-error:read-escaped-char ()
@@ -74,7 +83,7 @@ aiueo"
 (ert-deftest toml-test:read-string ()
   (toml-test:buffer-setup
    "\"GitHub Cofounder & CEO\\nLikes tater tots and beer.\""
-   (should (equal "GitHub Cofounder & CEO\\nLikes tater tots and beer." (toml:read-string)))
+   (should (equal "GitHub Cofounder & CEO\nLikes tater tots and beer." (toml:read-string)))
    (should (toml:end-of-line-p))))
 
 (ert-deftest toml-test-error:read-string ()
@@ -816,11 +825,11 @@ Two\"\"\""
 (ert-deftest toml-test:read-multiline-basic-string-escapes ()
   (toml-test:buffer-setup
    "\"\"\"Line1\\nLine2\"\"\""
-   (should (equal "Line1\\nLine2" (toml:read-string))))
+   (should (equal "Line1\nLine2" (toml:read-string))))
 
   (toml-test:buffer-setup
    "\"\"\"Tab\\there\"\"\""
-   (should (equal "Tab\\there" (toml:read-string)))))
+   (should (equal "Tab\there" (toml:read-string)))))
 
 (ert-deftest toml-test:read-multiline-basic-string-quotes ()
   (toml-test:buffer-setup

--- a/toml.el
+++ b/toml.el
@@ -40,22 +40,17 @@
 
 (require 'parse-time)
 
-(defconst toml->special-escape-characters
-  '(?b ?t ?n ?f ?r ?\" ?\/ ?\\)
-  "Characters which are escaped in TOML.
-
-\\b     - backspace       (U+0008)
-\\t     - tab             (U+0009)
-\\n     - linefeed        (U+000A)
-\\f     - form feed       (U+000C)
-\\r     - carriage return (U+000D)
-\\\"     - quote           (U+0022)
-\\\/     - slash           (U+002F)
-\\\\     - backslash       (U+005C)
-
-notes:
-
- Excluded four hex (\\uXXXX).  Do check in `toml:read-escaped-char'")
+(defconst toml->escape-sequence-alist
+  '((?b . ?\b)    ; backspace       (U+0008)
+    (?t . ?\t)    ; tab             (U+0009)
+    (?n . ?\n)    ; linefeed        (U+000A)
+    (?f . ?\f)    ; form feed       (U+000C)
+    (?r . ?\r)    ; carriage return (U+000D)
+    (?\" . ?\")   ; quote           (U+0022)
+    (?/ . ?/)     ; slash           (U+002F)
+    (?\\ . ?\\))  ; backslash       (U+005C)
+  "Alist mapping TOML escape characters to their actual values.
+Excludes \\uXXXX which is handled separately in `toml:read-escaped-char'.")
 
 (defconst toml->parse-dispatch-table
   (let ((table
@@ -232,12 +227,12 @@ Move point to the end of read characters."
   (unless (eq ?\\ (toml:read-char t))
     (signal 'toml-string-escape-error (list (point))))
   (let* ((char (toml:read-char t))
-         (special (memq char toml->special-escape-characters)))
+         (mapped (assq char toml->escape-sequence-alist)))
     (cond
-     (special (concat (list ?\\ char)))
+     (mapped (char-to-string (cdr mapped)))
      ((and (eq char ?u)
            (toml:search-forward "[0-9A-Fa-f]\\{4\\}"))
-      (concat "\\u" (match-string 0)))
+      (char-to-string (string-to-number (match-string 0) 16)))
      (t (signal 'toml-string-unicode-escape-error (list (point)))))))
 
 (defun toml:read-multiline-basic-string ()
@@ -275,18 +270,17 @@ Move point to the end of read strings."
   ;; Check for multiline string (""")
   (if (looking-at "\"\"\"")
       (toml:read-multiline-basic-string)
-    (let ((characters '())
-          (char (toml:read-char)))
-      (while (not (eq char ?\"))
+    (forward-char)  ; skip opening "
+    (let ((characters '()))
+      (while (not (eq (toml:get-char-at-point) ?\"))
         (when (toml:end-of-line-p)
           (signal 'toml-string-error (list (point))))
-        (push (if (eq char ?\\)
-                  (toml:read-escaped-char)
-                (toml:read-char))
-              characters)
-        (setq char (toml:get-char-at-point)))
-      (forward-char)
-      (apply 'concat (nreverse characters)))))
+        (let ((char (toml:get-char-at-point)))
+          (if (eq char ?\\)
+              (push (toml:read-escaped-char) characters)
+            (push (toml:read-char) characters))))
+      (forward-char)  ; skip closing "
+      (apply #'concat (nreverse characters)))))
 
 (defun toml:read-multiline-literal-string ()
   "Read multiline literal string (enclosed in ''') at point.


### PR DESCRIPTION
This is a follow-up to https://github.com/gongo/emacs-toml/pull/31