### PR TITLE
Support `\UXXXXXXXX` (8-digit Unicode escape) in basic strings

### DIFF
--- a/toml-test.el
+++ b/toml-test.el
@@ -68,14 +68,26 @@ aiueo"
                   ("\\/" . "/")
                   ("\\\\" . "\\")
                   ("\\u0041" . "A")
-                  ("\\u1234" . "\u1234")))
+                  ("\\u1234" . "\u1234")
+                  ("\\U0001F600" . "😀")
+                  ("\\U00000041" . "A")))
     (toml-test:buffer-setup
      (car test)
      (should (equal (cdr test) (toml:read-escaped-char)))
      (should (toml:end-of-line-p)))))
 
 (ert-deftest toml-test-error:read-escaped-char ()
-  (dolist (char '(" " " \\b" "a" "\\a" "\\c" "\\uABC!" "\\u____"))
+  (dolist (char '(" "
+		  " \\b"
+		  "a"
+		  "\\a"
+		  "\\c"
+		  "\\uABC!"
+		  "\\u____"
+                  "\\UABCDEFG!"
+		  "\\U________"
+		  "\\U0001F60"
+		  ))
     (toml-test:buffer-setup
      char
      (should-error (toml:read-escaped-char) :type 'toml-string-escape-error))))

--- a/toml.el
+++ b/toml.el
@@ -233,6 +233,9 @@ Move point to the end of read characters."
      ((and (eq char ?u)
            (toml:search-forward "[0-9A-Fa-f]\\{4\\}"))
       (char-to-string (string-to-number (match-string 0) 16)))
+     ((and (eq char ?U)
+           (toml:search-forward "[0-9A-Fa-f]\\{8\\}"))
+      (char-to-string (string-to-number (match-string 0) 16)))
      (t (signal 'toml-string-unicode-escape-error (list (point)))))))
 
 (defun toml:read-multiline-basic-string ()


### PR DESCRIPTION
## Motivation

Previously only `\uXXXX` (lowercase u, 4-digit)