### PR TITLE
Relax bare key constraints

### DIFF
--- a/toml-test.el
+++ b/toml-test.el
@@ -381,6 +381,26 @@ aiueo"
    "\"\" = name"
    (should (equal "" (toml:read-key)))
    (should (eq ?n (toml:get-char-at-point))))
+
+  (toml-test:buffer-setup
+   "1biueo = true"
+   (should (equal "1biueo" (toml:read-key)))
+   (should (eq ?t (toml:get-char-at-point))))
+
+  (toml-test:buffer-setup
+   "connection_ = 5000"
+   (should (equal "connection_" (toml:read-key)))
+   (should (eq ?5 (toml:get-char-at-point))))
+
+  (toml-test:buffer-setup
+   "1234 = 42"
+   (should (equal "1234" (toml:read-key)))
+   (should (eq ?4 (toml:get-char-at-point))))
+
+  (toml-test:buffer-setup
+   "_ = 1"
+   (should (equal "_" (toml:read-key)))
+   (should (eq ?1 (toml:get-char-at-point))))
   )
 
 
@@ -393,16 +413,6 @@ aiueo"
   ;; key only
   (toml-test:buffer-setup
    "key"
-   (should-error (toml:read-key) :type 'toml-key-error))
-
-  ;; start with number.
-  (toml-test:buffer-setup
-   "1biueo = true"
-   (should-error (toml:read-key) :type 'toml-key-error))
-
-  ;; end with underscore
-  (toml-test:buffer-setup
-   "connection_ = 5000"
    (should-error (toml:read-key) :type 'toml-key-error))
 
   ;; multiline not allowed
@@ -520,6 +530,14 @@ aiueo"
    (should (equal '(:type array :keys ("ai-ueo")) (toml:read-table))))
 
   (toml-test:buffer-setup
+   "[1234]"
+   (should (equal '(:type single :keys ("1234")) (toml:read-table))))
+
+  (toml-test:buffer-setup
+   "[foo.bar_]"
+   (should (equal '(:type single :keys ("foo" "bar_")) (toml:read-table))))
+
+  (toml-test:buffer-setup
    "[[servers]]
     [[servers.alpha]]
 
@@ -537,11 +555,6 @@ aiueo"
 (ert-deftest toml-test-error:read-table ()
   (toml-test:buffer-setup
    "[]"
-   (should-error (toml:read-table) :type 'toml-table-error))
-
-  ;; end with underscore "_"
-  (toml-test:buffer-setup
-   "[foo.bar_]"
    (should-error (toml:read-table) :type 'toml-table-error))
 
   ;; end with period "."

--- a/toml.el
+++ b/toml.el
@@ -457,11 +457,11 @@ Behavior differences:
     (while (and (not (eobp))
                 (or (null table-type) (eq table-type 'single))
                 (char-equal (toml:get-char-at-point) ?\[))
-      (if (toml:search-forward "\\(\\[\\{1,2\\}\\)\\([a-zA-Z][a-zA-Z0-9_\\.-]*\\)\\(\\]\\{1,2\\}\\)")
+      (if (toml:search-forward "\\(\\[\\{1,2\\}\\)\\([A-Za-z0-9_-][A-Za-z0-9_\\.-]*\\)\\(\\]\\{1,2\\}\\)")
           (let* ((brackets-before (match-string-no-properties 1)) ;;  "["  in "[xxx]"
                  (brackets-after (match-string-no-properties 3))  ;;  "]"  in "[xxx]"
                  (table-string (match-string-no-properties 2)))   ;; "xxx" in "[xxx]"
-            (when (string-match "\\(_\\|\\.\\)\\'" table-string)
+            (when (string-match "\\.\\'" table-string)
               (signal 'toml-table-error (list (point))))
             (unless (= (length brackets-before) (length brackets-after))
               (signal 'toml-table-error (list (point))))
@@ -483,11 +483,8 @@ Behavior differences:
                   ((char-equal (toml:get-char-at-point) ?\[) nil)
                   ((char-equal (toml:get-char-at-point) ?\") (toml:read-string))
                   ((char-equal (toml:get-char-at-point) ?\') (toml:read-literal-string))
-                  ((toml:search-forward "\\([a-zA-Z][a-zA-Z0-9_-]*\\)")
-                   (let ((k (match-string-no-properties 1)))
-                     (when (string-match "_\\'" k)
-                       (signal 'toml-key-error (list (point))))
-                     k))
+                  ((toml:search-forward "\\([A-Za-z0-9_-]+\\)")
+                   (match-string-no-properties 1))
                   (t (signal 'toml-key-error (list (point)))))
                (toml-string-error
                 (signal 'toml-key-error (cdr err))))))


### PR DESCRIPTION
see #47 

> Bare keys may only contain ASCII letters, ASCII digits, underscores, and dashes `(A-Za-z0-9_-)` . Note that bare keys are allowed to be composed of only ASCII digits, e.g. `1234` , but are always interpreted as strings.
>
> https://toml.io/en/v0.5.0#keys