### PR TITLE
Reject control characters in strings

### DIFF
--- a/toml-test.el
+++ b/toml-test.el
@@ -116,6 +116,42 @@ aiueo"
      str
      (should-error (toml:read-string) :type 'toml-string-error))))
 
+(ert-deftest toml-test:read-string-control-char ()
+  (dolist (test '((#x09 . "\t") ;; U+0009 (TAB)
+                  (#x20 . " ") ;; U+0020 (SPACE)
+		  (#x7E . "~") ;; U+007E (TILDE)
+                  ))
+    (toml-test:buffer-setup
+     (format "\"%c\"" (car test))
+     (let ((result (toml:read-string)))
+       (should (equal (cdr test) result))))
+
+    (toml-test:buffer-setup
+     (format "'%c'" (car test))
+     (let ((result (toml:read-literal-string)))
+       (should (equal (cdr test) result))))
+    ))
+
+(ert-deftest toml-test-error:read-string-control-char ()
+  "Test that control characters are rejected in basic strings."
+  (dolist (char '(#x00 ;; U+0000 (null)
+                  #x1F ;; U+001F (last C0 control char)
+		  #x7F ;; U+007F (DEL)
+                  ))
+    (toml-test:buffer-setup
+     (format "\"%c\"" char)
+     (should-error (toml:read-string) :type 'toml-string-error))))
+
+(ert-deftest toml-test-error:read-literal-string-control-char ()
+  "Test that control characters are rejected in literal strings."
+  (dolist (char '(#x00 ;; U+0000 (null)
+                  #x1F ;; U+001F (last C0 control char)
+		  #x7F ;; U+007F (DEL)
+                  ))
+    (toml-test:buffer-setup
+     (format "'%c'" char)
+     (should-error (toml:read-literal-string) :type 'toml-string-error))))
+
 (ert-deftest toml-test:read-boolean ()
   (toml-test:buffer-setup
    "true"

--- a/toml.el
+++ b/toml.el
@@ -289,6 +289,13 @@ Move point to the end of read characters."
         (char-to-string code-point)))
      (t (signal 'toml-string-unicode-escape-error (list (point)))))))
 
+(defun toml:control-char-p (char)
+  "Return non-nil if CHAR is a control character forbidden in TOML strings.
+Control characters are U+0000 to U+001F (except TAB U+0009) and U+007F."
+  (or (and (>= char #x00) (<= char #x08))
+      (and (>= char #x0A) (<= char #x1F))
+      (= char #x7F)))
+
 (defun toml:read-multiline-basic-string ()
   "Read multiline basic string (enclosed in \"\"\") at point.
 Handles escape sequences, line-ending backslash continuation,
@@ -308,6 +315,10 @@ and trims immediate newline after opening delimiter."
         (goto-char (match-end 0)))
        (t
         (let ((char (toml:get-char-at-point)))
+          (when (and (toml:control-char-p char)
+                     (not (eq char ?\n))
+                     (not (eq char ?\r)))
+            (signal 'toml-string-error (list (point))))
           ;; Regular escape sequence or regular character
           (if (eq char ?\\)
               (push (toml:read-escaped-char) characters)
@@ -330,6 +341,8 @@ Move point to the end of read strings."
         (when (toml:end-of-line-p)
           (signal 'toml-string-error (list (point))))
         (let ((char (toml:get-char-at-point)))
+          (when (toml:control-char-p char)
+            (signal 'toml-string-error (list (point))))
           (if (eq char ?\\)
               (push (toml:read-escaped-char) characters)
             (push (toml:read-char) characters))))
@@ -348,6 +361,11 @@ No escape processing. Trims immediate newline after opening delimiter."
     (while (not (looking-at "'''"))
       (when (eobp)
         (signal 'toml-string-error (list (point))))
+      (let ((char (toml:get-char-at-point)))
+        (when (and (toml:control-char-p char)
+                   (not (eq char ?\n))
+                   (not (eq char ?\r)))
+          (signal 'toml-string-error (list (point)))))
       (push (toml:read-char) characters))
     ;; Skip the closing '''
     (forward-char 3)
@@ -365,6 +383,9 @@ No escape processing. Trims immediate newline after opening delimiter."
       (while (not (eq (toml:get-char-at-point) ?\'))
         (when (toml:end-of-line-p)
           (signal 'toml-string-error (list (point))))
+        (let ((char (toml:get-char-at-point)))
+          (when (toml:control-char-p char)
+            (signal 'toml-string-error (list (point)))))
         (push (toml:read-char) characters))
       (forward-char)
       (apply #'concat (nreverse characters)))))


### PR DESCRIPTION
https://toml.io/en/v0.5.0#string

**Basic strings**

> Any Unicode character may be used except those that must be escaped: quotation mark, backslash, and the control characters (U+0000 to U+001F, U+007F).

**Multi-line basic strings**

> Any Unicode character may be used except those that must be escaped: backslash and the control characters (U+0000 to U+001F, U+007F).

**Literal strings and multi-line literal strings**

> Control characters other than tab are not permitted in a literal string. 