### PR TITLE
Reject control characters in comments.

### DIFF
--- a/toml-test.el
+++ b/toml-test.el
@@ -152,6 +152,22 @@ aiueo"
      (format "'%c'" char)
      (should-error (toml:read-literal-string) :type 'toml-string-error))))
 
+(ert-deftest toml-test-error:read-comment ()
+  "Test that control characters are rejected in comments."
+  (dolist (char '(#x00 ;; U+0000 (null)
+                  #x1F ;; U+001F (last C0 control char)
+                  #x7F ;; U+007F (DEL)
+                  ))
+    (toml-test:buffer-setup
+     (format "# comment %c here" char)
+     (should-error (toml:seek-readable-point) :type 'toml-comment-error)))
+  ;; Tab (U+0009) is allowed in comments
+  (toml-test:buffer-setup
+   (format "# comment %c here" #x09)
+   (should-not (condition-case nil
+                   (progn (toml:seek-readable-point) nil)
+                 (toml-comment-error t)))))
+
 (ert-deftest toml-test:read-boolean ()
   (toml-test:buffer-setup
    "true"

--- a/toml.el
+++ b/toml.el
@@ -187,6 +187,10 @@ Excludes \\uXXXX which is handled separately in `toml:read-escaped-char'.")
 (put 'toml-array-table-error 'error-conditions
      '(toml-array-table-error toml-error error))
 
+(put 'toml-comment-error 'error-message "Bad comment")
+(put 'toml-comment-error 'error-conditions
+     '(toml-comment-error toml-error error))
+
 (put 'toml-inline-table-error 'error-message "Bad inline table")
 (put 'toml-inline-table-error 'error-conditions
      '(toml-inline-table-error toml-error error))
@@ -235,7 +239,11 @@ Skip target:
   (toml:seek-non-whitespace)
   (while (and (not (eobp))
               (char-equal (toml:get-char-at-point) ?#))
-    (end-of-line)
+    (forward-char) ; skip '#'
+    (while (and (not (eobp)) (not (toml:end-of-line-p)))
+      (when (toml:control-char-p (toml:get-char-at-point))
+        (signal 'toml-comment-error (list (point))))
+      (forward-char))
     (unless (eobp)
       (toml:seek-beginning-of-next-line)
       (toml:seek-non-whitespace))))


### PR DESCRIPTION
close #64 

> Control characters other than tab (U+0000 to U+0008, U+000A to U+001F, U+007F) are not permitted in comments.
>
> https://toml.io/en/v1.0.0#comment