### PR TITLE
Prohibit redefining tables implicitly created by dotted keys

### DIFF
--- a/toml-test.el
+++ b/toml-test.el
@@ -1655,3 +1655,41 @@ regex = '''\\d{4}-\\d{2}-\\d{2}'''
   (let ((parsed (toml:read-from-string "a.b = 1\nc = { d = 2 }")))
     (should (equal 1 (cdr (assoc "b" (cdr (assoc "a" parsed))))))
     (should (equal 2 (cdr (assoc "d" (cdr (assoc "c" parsed))))))))
+
+(ert-deftest toml-test-error:dotted-key-implicit-table-reopen-root ()
+  "Reopening implicit table defined by root dotted key should error."
+  (should-error (toml:read-from-string "fruit.apple.color = \"red\"\n[fruit.apple]")
+                :type 'toml-redefine-table-error))
+
+(ert-deftest toml-test-error:dotted-key-implicit-table-reopen-under-table ()
+  "Reopening implicit table defined by dotted key under [table] should error."
+  (should-error (toml:read-from-string "[fruit]\napple.color = \"red\"\n[fruit.apple]")
+                :type 'toml-redefine-table-error))
+
+(ert-deftest toml-test-error:dotted-key-implicit-table-reopen-nested ()
+  "Reopening nested implicit table defined by dotted key should error."
+  (should-error (toml:read-from-string "[fruit]\napple.taste.sweet = true\n[fruit.apple.taste]")
+                :type 'toml-redefine-table-error))
+
+(ert-deftest toml-test-error:dotted-key-implicit-table-reopen-self ()
+  "Reopening root implicit table itself should error."
+  (should-error (toml:read-from-string "a.b.c = 1\n[a]")
+                :type 'toml-redefine-table-error))
+
+(ert-deftest toml-test:dotted-key-new-subtable-ok ()
+  "New subtable under dotted-key-defined table should be allowed."
+  (let ((parsed (toml:read-from-string "fruit.apple.color = \"red\"\n[fruit.apple.texture]\nsmooth = true")))
+    (should (equal "red" (cdr (assoc "color" (cdr (assoc "apple" (cdr (assoc "fruit" parsed))))))))
+    (should (equal t (cdr (assoc "smooth" (cdr (assoc "texture" (cdr (assoc "apple" (cdr (assoc "fruit" parsed))))))))))))
+
+(ert-deftest toml-test:dotted-key-multiple-same-prefix-ok ()
+  "Multiple dotted keys with same implicit prefix should be allowed."
+  (let ((parsed (toml:read-from-string "a.b = 1\na.c = 2")))
+    (should (equal 1 (cdr (assoc "b" (cdr (assoc "a" parsed))))))
+    (should (equal 2 (cdr (assoc "c" (cdr (assoc "a" parsed))))))))
+
+(ert-deftest toml-test:dotted-key-under-table-same-prefix-ok ()
+  "Multiple dotted keys with same prefix under [table] should be allowed."
+  (let ((parsed (toml:read-from-string "[a]\nb.c = 1\nb.d = 2")))
+    (should (equal 1 (cdr (assoc "c" (cdr (assoc "b" (cdr (assoc "a" parsed))))))))
+    (should (equal 2 (cdr (assoc "d" (cdr (assoc "b" (cdr (assoc "a" parsed))))))))))

--- a/toml.el
+++ b/toml.el
@@ -1101,6 +1101,15 @@ Example:
                 (dolist (path (toml:collect-inline-table-paths base-path current-value))
                   (push path inline-table-registry))))
 
+            ;; Register dotted-key-defined implicit tables in table-history
+            ;; to prevent [table] headers from reopening them (TOML v1.0.0)
+            (when (and (not current-array-table) dotted-table)
+              (let ((prefix current-table))
+                (dolist (seg dotted-table)
+                  (setq prefix (append prefix (list seg)))
+                  (unless (member prefix table-history)
+                    (push prefix table-history)))))
+
             ;; Add to appropriate structure
             (if current-array-table
                 ;; Add to array table element


### PR DESCRIPTION
close #69 